### PR TITLE
Import functions

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -668,3 +668,48 @@ function import_data(url::String, data::Dict{Symbol,T}, comment::String) where {
         end
     end
 end
+function import_data(url::String, data::ObjectClass, comment::String)
+    import_data(
+        url,
+        Dict(
+            :object_classes => [data.name],
+            :object_parameters => [
+                [data.name, parameter_name, _unparse_db_value(parameter_default_value)]
+                for (parameter_name, parameter_default_value) in data.parameter_defaults
+            ],
+            :objects => [
+                [data.name, object.name] for object in data.objects
+            ],
+            :object_parameter_values => [
+                [data.name, object.name, parameter_name, _unparse_db_value(parameter_value)]
+                for object in keys(data.parameter_values)
+                for (parameter_name, parameter_value) in data.parameter_values[object]
+            ]
+        ),
+        comment
+    )
+end
+function import_data(url::String, data::RelationshipClass, comment::String)
+    for oc in filter!(oc -> oc.name in data.object_class_names, object_class())
+        import_data(url, oc, comment)
+    end
+    import_data(
+        url,
+        Dict(
+            :relationship_classes => [[data.name, data.object_class_names]],
+            :relationship_parameters => [
+                [data.name, parameter_name, _unparse_db_value(parameter_default_value)]
+                for (parameter_name, parameter_default_value) in data.parameter_defaults
+            ],
+            :relationships => [
+                [data.name, getfield.([relationship...], :name)] for relationship in data.relationships
+            ],
+            :relationship_parameter_values => [
+                [data.name, getfield.([relationship...], :name), parameter_name, _unparse_db_value(parameter_value)]
+                for relationship in keys(data.parameter_values)
+                for (parameter_name, parameter_value) in data.parameter_values[relationship]
+            ]
+        ),
+        comment
+    )
+end

--- a/src/util.jl
+++ b/src/util.jl
@@ -431,7 +431,7 @@ function _unparse_time_pattern(pc::PeriodCollection)
     join(arr, intersection_op)
 end
 
-_unparse_db_value(x) = x
+_unparse_db_value(x) = string(x)
 _unparse_db_value(x::DateTime) = Dict("type" => "date_time", "data" => string(Dates.format(x, db_df)))
 _unparse_db_value(x::T) where {T<:Period} = Dict("type" => "duration", "data" => _unparse_duration(x))
 function _unparse_db_value(x::Array{T}) where {T}

--- a/src/util.jl
+++ b/src/util.jl
@@ -431,7 +431,7 @@ function _unparse_time_pattern(pc::PeriodCollection)
     join(arr, intersection_op)
 end
 
-_unparse_db_value(x) = string(x)
+_unparse_db_value(x) = x
 _unparse_db_value(x::DateTime) = Dict("type" => "date_time", "data" => string(Dates.format(x, db_df)))
 _unparse_db_value(x::T) where {T<:Period} = Dict("type" => "duration", "data" => _unparse_duration(x))
 function _unparse_db_value(x::Array{T}) where {T}
@@ -453,6 +453,9 @@ function _unparse_db_value(x::Map{K,V}) where {K,V}
         "index_type" => _inner_type_str(K),
         "data" => [(i, _unparse_db_value(v)) for (i, v) in zip(x.indexes, x.values)],
     )
+end
+function _unparse_db_value(x::AbstractParameterValue)
+    hasproperty(x, :value) ? _unparse_db_value(x.value) : nothing
 end
 
 function _import_spinedb_api()


### PR DESCRIPTION
Convenience methods for importing `ObjectClass` and `RelationshipClass` objects into a db via the `import_data` function.