### PR TITLE
Fixing a bug in the `RelationshipClass` `_to_dict()` conversion

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -612,7 +612,11 @@ end
 function _to_dict(rel_cls::RelationshipClass)
     Dict(
         :object_classes => unique(rel_cls.intact_object_class_names),
-        :objects => unique(obj.name for rel in rel_cls.relationships for obj in rel), 
+        :objects => unique(
+            [obj_cls_name, obj.name]
+            for obj_cls_name in rel_cls.intact_object_class_names
+            for obj in unique(getfield.(rel_cls.relationships, obj_cls_name))
+        ), 
         :relationship_classes => [[rel_cls.name, rel_cls.intact_object_class_names]],
         :relationship_parameters => [
             [rel_cls.name, parameter_name, _unparse_db_value(parameter_default_value)]

--- a/src/util.jl
+++ b/src/util.jl
@@ -614,8 +614,8 @@ function _to_dict(rel_cls::RelationshipClass)
         :object_classes => unique(rel_cls.intact_object_class_names),
         :objects => unique(
             [obj_cls_name, obj.name]
-            for obj_cls_name in rel_cls.intact_object_class_names
-            for obj in unique(getfield.(rel_cls.relationships, obj_cls_name))
+            for (i,obj_cls_name) in enumerate(rel_cls.intact_object_class_names)
+            for obj in unique(getfield.(rel_cls.relationships, rel_cls.object_class_names[i]))
         ), 
         :relationship_classes => [[rel_cls.name, rel_cls.intact_object_class_names]],
         :relationship_parameters => [

--- a/test/util.jl
+++ b/test/util.jl
@@ -52,7 +52,7 @@ end
     d_obs = SpineInterface._to_dict(cls)
     d_exp = Dict(
         :object_classes => [:cat, :dog],
-        :objects => [:silvester, :tom, :pluto],
+        :objects => [[:cat, :silvester], [:cat, :tom], [:dog, :pluto]],
         :relationship_classes => [[:cat__cat__dog, [:cat, :cat, :dog]]],
         :relationships => [[:cat__cat__dog, [:silvester, :tom, :pluto]], [:cat__cat__dog, [:tom, :silvester, :pluto]]],
         :relationship_parameters => [[:cat__cat__dog, :age, 9]],


### PR DESCRIPTION
The `:objects` entry lacks `ObjectClass` name information, which messes up the import.