### PR TITLE
Bug fix: adding some (necessary) brackets

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -361,7 +361,7 @@ function overlap_duration(a::TimeSlice, b::TimeSlice)
     overlaps(a, b) || return 0.0
     overlap_start = max(start(a), start(b))
     overlap_end = min(end_(a), end_(b))
-    duration(a) * Minute(overlap_end - overlap_start) / Minute(end_(a) - start(a))
+    duration(a) * (Minute(overlap_end - overlap_start) / Minute(end_(a) - start(a)))
 end
 
 """


### PR DESCRIPTION
Otherwise the function first multiplies Minutes with the duration and that causes problems (when using e.g. model_duration unit of 1 hour)