### PR TITLE
WIP: Unit test fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpineInterface"
 uuid = "0cda1612-498a-11e9-3c92-77fa82595a4f"
 authors = ["Spine Project consortium <spine_info@vtt.fi>"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/util.jl
+++ b/src/util.jl
@@ -553,7 +553,7 @@ function _import_spinedb_api()
 end
 
 function _do_create_db_handler(db_url::String, upgrade::Bool)
-    db_server.DBHandler(db_url, upgrade)
+    db_url == "sqlite://" ? db_server.PersistentDBHandler(db_url, upgrade) : db_server.DBHandler(db_url, upgrade)
 end
 
 function _create_db_handler(db_url::String, upgrade::Bool)

--- a/test/api.jl
+++ b/test/api.jl
@@ -223,7 +223,7 @@ end
     # Add parameter values of all types
     scalar_value = 18
     array_data = [4, 8, 7]
-    array_value = Dict("type" => "array", "data" => PyVector(array_data))
+    array_value = Dict("type" => "array", "value_type" => "float", "data" => PyVector(array_data))
     time_pattern_data = Dict("M1-4,M9-10" => 300, "M5-8" => 221.5)
     time_pattern_value = Dict("type" => "time_pattern", "data" => time_pattern_data)
     time_series_data = [1.0, 4.0, 5.0, NaN, 7.0]

--- a/test/api.jl
+++ b/test/api.jl
@@ -273,3 +273,5 @@ end
     using_spinedb(db_url)
     @test maximum_parameter_value(people_count) == 300.0
 end
+# Clear in-memory DB for safety
+import_test_data(db_url; object_classes=[])

--- a/test/api.jl
+++ b/test/api.jl
@@ -17,8 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################################
 
+db_url = "sqlite://"
 @testset "indices" begin
-    url = "sqlite://"
     object_classes = ["institution", "country"]
     relationship_classes = [["institution__country", ["institution", "country"]]]
     object_parameters = [["institution", "since_year"]]
@@ -32,9 +32,8 @@
         ["institution__country", ["KTH", "Sweden"], "people_count", 3],
         ["institution__country", ["KTH", "France"], "people_count", 1],
     ]
-    db_map = db_api.DatabaseMapping(url, create=true)
-    db_api.import_data(
-        db_map;
+    import_test_data(
+        db_url;
         object_classes=object_classes,
         relationship_classes=relationship_classes,
         objects=objects,
@@ -44,8 +43,7 @@
         object_parameter_values=object_parameter_values,
         relationship_parameter_values=relationship_parameter_values,
     )
-    db_map.commit_session("No comment")
-    using_spinedb(db_map)
+    using_spinedb(db_url)
     @test collect(indices(people_count)) == [
         (institution=institution(:KTH), country=country(:Sweden)),
         (institution=institution(:KTH), country=country(:France)),
@@ -82,15 +80,12 @@ end
     @test end_(t0_2) == DateTime(2, 1, 1, 0, 44)
 end
 @testset "add_entities" begin
-    url = "sqlite://"
     @testset "add_objects" begin
         object_classes = ["institution"]
         institutions = ["VTT", "KTH"]
         objects = [["institution", x] for x in institutions]
-        db_map = db_api.DatabaseMapping(url, create=true)
-        db_api.import_data(db_map; object_classes=object_classes, objects=objects)
-        db_map.commit_session("No comment")
-        using_spinedb(db_map)
+        import_test_data(db_url; object_classes=object_classes, objects=objects)
+        using_spinedb(db_url)
         @test length(institution()) === 2
         add_objects!(institution, [institution()[1], Object(:KUL), Object(:ER)])
         @test length(institution()) === 4
@@ -108,16 +103,14 @@ end
         object_tuples =
             [["VTT", "Finland"], ["KTH", "Sweden"], ["KTH", "France"], ["KUL", "Belgium"], ["UCD", "Ireland"]]
         relationships = [["institution__country", x] for x in object_tuples]
-        db_map = db_api.DatabaseMapping(url, create=true)
-        db_api.import_data(
-            db_map;
+        import_test_data(
+            db_url;
             object_classes=object_classes,
             relationship_classes=relationship_classes,
             objects=objects,
             relationships=relationships,
         )
-        db_map.commit_session("No comment")
-        using_spinedb(db_map)
+        using_spinedb(db_url)
         @test length(institution__country()) === 5
         add_relationships!(
             institution__country,
@@ -213,7 +206,6 @@ end
     @test is_varying(another_call)
 end
 @testset "maximum_parameter_value" begin
-    url = "sqlite://"
     object_classes = ["institution", "country"]
     relationship_classes = [["institution__country", ["institution", "country"]]]
     relationship_parameters = [["institution__country", "people_count"]]
@@ -269,9 +261,8 @@ end
         ["institution__country", ["VTT", "Finland"], "people_count", map_value],
         ["institution__country", ["VTT", "Ireland"], "people_count", nothing],
     ]
-    db_map = db_api.DatabaseMapping(url, create=true)
-    db_api.import_data(
-        db_map;
+    import_test_data(
+        db_url;
         object_classes=object_classes,
         relationship_classes=relationship_classes,
         objects=objects,
@@ -279,7 +270,6 @@ end
         relationship_parameters=relationship_parameters,
         relationship_parameter_values=relationship_parameter_values,
     )
-    db_map.commit_session("No comment")
-    using_spinedb(db_map)
+    using_spinedb(db_url)
     @test maximum_parameter_value(people_count) == 300.0
 end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -19,6 +19,7 @@
 
 # Initialise an in-memory database to avoid `StackOverflowError` when running this file solo???
 using_spinedb("sqlite://")
+
 @testset "constructors" begin
     ducks = [Object(:Daffy), Object(:Donald)]
     duck = ObjectClass(:duck, ducks)

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -17,6 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################################
 
+# Initialise an in-memory database to avoid `StackOverflowError`???
+using_spinedb("sqlite://")
 @testset "constructors" begin
     ducks = [Object(:Daffy), Object(:Donald)]
     duck = ObjectClass(:duck, ducks)

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################################
 
-# Initialise an in-memory database to avoid `StackOverflowError`???
+# Initialise an in-memory database to avoid `StackOverflowError` when running this file solo???
 using_spinedb("sqlite://")
 @testset "constructors" begin
     ducks = [Object(:Daffy), Object(:Donald)]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,16 @@ using PyCall
 using Dates
 using JSON
 
+# Original tests used a slightly different syntax for `import_data`, so correct it here for convenience.
+SpineInterface.import_data(db_url::String; kwargs...) = SpineInterface.import_data(db_url, Dict(kwargs...), "testing")
+
+# Convenience function for overwriting in-memory Database with test data.
+function import_test_data(db_url::String; kwargs...)
+    SpineInterface._import_spinedb_api()
+    SpineInterface.db_server.close_persistent_db_map(db_url)
+    import_data(db_url; kwargs...)
+end
+
 @testset begin
     include("using_spinedb.jl")
     include("api.jl")

--- a/test/using_spinedb.jl
+++ b/test/using_spinedb.jl
@@ -287,3 +287,5 @@ end
         @test apero_time(; country=France, s=drunk, t0=t0, whocares=t0, t=t2_3) == 5.6
     end
 end
+# Clear in-memory DB for safety
+import_test_data(db_url; object_classes=[])

--- a/test/using_spinedb.jl
+++ b/test/using_spinedb.jl
@@ -153,7 +153,7 @@ end
     end
     @testset "array" begin
         data = [4, 8, 7]
-        value = Dict("type" => "array", "data" => PyVector(data))
+        value = Dict("type" => "array", "value_type" => "float", "data" => PyVector(data))
         object_parameter_values = [["country", "France", "apero_time", value]]
         import_data(db_url; object_parameter_values=object_parameter_values)
         using_spinedb(db_url)

--- a/test/using_spinedb.jl
+++ b/test/using_spinedb.jl
@@ -16,18 +16,15 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################################
+db_url = "sqlite://"
 @testset "using_spinedb - basics" begin
-    SpineInterface._import_spinedb_api()
-    url = "sqlite://"
     @testset "object_class" begin
         object_classes = ["institution"]
         institutions = ["VTT", "KTH", "KUL", "ER", "UCD"]
         objects = [["institution", x] for x in (institutions..., "Spine")]
         object_groups = [["institution", "Spine", x] for x in institutions]
-        db_map = db_api.DatabaseMapping(url, create=true)
-        db_api.import_data(db_map; object_classes=object_classes, objects=objects, object_groups=object_groups)
-        db_map.commit_session("No comment")
-        using_spinedb(db_map)
+        import_test_data(db_url; object_classes=object_classes, objects=objects, object_groups=object_groups)
+        using_spinedb(db_url)
         @test length(institution()) === 6
         @test all(x isa Object for x in institution())
         @test [x.name for x in institution()] == vcat(Symbol.(institutions), :Spine)
@@ -66,16 +63,14 @@
             [["institution__country", x] for x in institution_country_tuples],
             [["country__neighbour", x] for x in country_neighbour_tuples],
         )
-        db_map = db_api.DatabaseMapping(url, create=true)
-        db_api.import_data(
-            db_map;
+        import_test_data(
+            db_url;
             object_classes=object_classes,
             relationship_classes=relationship_classes,
             objects=objects,
             relationships=relationships,
         )
-        db_map.commit_session("No comment")
-        using_spinedb(db_map)
+        using_spinedb(db_url)
         @test length(institution__country()) === 7
         @test all(x isa RelationshipLike for x in institution__country())
         @test [x.name for x in institution__country(country=country(:France))] == [:KTH, :ER]
@@ -109,10 +104,9 @@
         relationship_parameter_values = [
             ["institution__country", ["KTH", "Sweden"], "people_count", 3],
             ["institution__country", ["KTH", "France"], "people_count", 1],
-        ]
-        db_map = db_api.DatabaseMapping(url, create=true)        
-        db_api.import_data(
-            db_map;
+        ]    
+        import_test_data(
+            db_url;
             object_classes=object_classes,
             relationship_classes=relationship_classes,
             objects=objects,
@@ -122,8 +116,7 @@
             object_parameter_values=object_parameter_values,
             relationship_parameter_values=relationship_parameter_values,
         )
-        db_map.commit_session("No comment")
-        using_spinedb(db_map)
+        using_spinedb(db_url)
         @test all(x isa RelationshipLike for x in institution__country())
         @test people_count(institution=institution(:KTH), country=country(:France)) == 1
         @test people_count(institution=institution(:KTH), country=country(:Sweden)) == 3
@@ -136,40 +129,34 @@
     end
 end
 @testset "using_spinedb - parameter value types" begin
-    url = "sqlite://"
     object_classes = ["country"]
     objects = [["country", "France"]]
     object_parameters = [["country", "apero_time"]]
-    db_map = db_api.DatabaseMapping(url, create=true)
-    db_api.import_data(db_map; object_classes=object_classes, objects=objects, object_parameters=object_parameters)
+    import_test_data(db_url; object_classes=object_classes, objects=objects, object_parameters=object_parameters)
     @testset "true" begin
         object_parameter_values = [["country", "France", "apero_time", true]]
-        db_api.import_data(db_map; object_parameter_values=object_parameter_values)
-        db_map.commit_session("No comment")
-        using_spinedb(db_map)
+        import_data(db_url; object_parameter_values=object_parameter_values)
+        using_spinedb(db_url)
         @test apero_time(country=country(:France))
     end
     @testset "false" begin
         object_parameter_values = [["country", "France", "apero_time", false]]
-        db_api.import_data(db_map; object_parameter_values=object_parameter_values)
-        db_map.commit_session("No comment")
-        using_spinedb(db_map)
+        import_data(db_url; object_parameter_values=object_parameter_values)
+        using_spinedb(db_url)
         @test !apero_time(country=country(:France))
     end
     @testset "string" begin
         object_parameter_values = [["country", "France", "apero_time", "now!"]]
-        db_api.import_data(db_map; object_parameter_values=object_parameter_values)
-        db_map.commit_session("No comment")
-        using_spinedb(db_map)
+        import_data(db_url; object_parameter_values=object_parameter_values)
+        using_spinedb(db_url)
         @test apero_time(country=country(:France)) == Symbol("now!")
     end
     @testset "array" begin
         data = [4, 8, 7]
         value = Dict("type" => "array", "data" => PyVector(data))
         object_parameter_values = [["country", "France", "apero_time", value]]
-        db_api.import_data(db_map; object_parameter_values=object_parameter_values)
-        db_map.commit_session("No comment")
-        using_spinedb(db_map)
+        import_data(db_url; object_parameter_values=object_parameter_values)
+        using_spinedb(db_url)
         @test apero_time(country=country(:France)) == data
         @test all(apero_time(country=country(:France), i=i) == v for (i, v) in enumerate(data))
     end
@@ -177,18 +164,16 @@ end
         data = "2000-01-01T00:00:00"
         value = Dict("type" => "date_time", "data" => data)
         object_parameter_values = [["country", "France", "apero_time", value]]
-        db_api.import_data(db_map; object_parameter_values=object_parameter_values)
-        db_map.commit_session("No comment")
-        using_spinedb(db_map)
+        import_data(db_url; object_parameter_values=object_parameter_values)
+        using_spinedb(db_url)
         @test apero_time(country=country(:France)) == DateTime(data)
     end
     @testset "duration" begin
         @testset for (k, (t, data)) in enumerate([(Minute, "m"), (Hour, "h"), (Day, "D"), (Month, "M"), (Year, "Y")])
             value = Dict("type" => "duration", "data" => string(k, data))
             object_parameter_values = [["country", "France", "apero_time", value]]
-            db_api.import_data(db_map; object_parameter_values=object_parameter_values)
-            db_map.commit_session("No comment")
-            using_spinedb(db_map)
+            import_data(db_url; object_parameter_values=object_parameter_values)
+            using_spinedb(db_url)
             @test apero_time(country=country(:France)) == t(k)
         end
     end
@@ -196,9 +181,8 @@ end
         data = Dict("M1-4,M9-10" => 300, "M5-8" => 221.5)
         value = Dict("type" => "time_pattern", "data" => data)
         object_parameter_values = [["country", "France", "apero_time", value]]
-        db_api.import_data(db_map; object_parameter_values=object_parameter_values)
-        db_map.commit_session("No comment")
-        using_spinedb(db_map)
+        import_data(db_url; object_parameter_values=object_parameter_values)
+        using_spinedb(db_url)
         France = country(:France)
         @test apero_time(country=France) isa SpineInterface.TimePattern
         @test apero_time(country=France, t=TimeSlice(DateTime(0, 1), DateTime(0, 2))) == 300
@@ -211,9 +195,8 @@ end
         index = Dict("start" => "2000-01-01T00:00:00", "resolution" => "1M", "repeat" => false, "ignore_year" => true)
         value = Dict("type" => "time_series", "data" => PyVector(data), "index" => index)
         object_parameter_values = [["country", "France", "apero_time", value]]
-        db_api.import_data(db_map; object_parameter_values=object_parameter_values)
-        db_map.commit_session("No comment")
-        using_spinedb(db_map)
+        import_data(db_url; object_parameter_values=object_parameter_values)
+        using_spinedb(db_url)
         France = country(:France)
         @test apero_time(country=France) isa TimeSeries
         @test apero_time(country=France, t=TimeSlice(DateTime(0, 1), DateTime(0, 2))) == 1.0
@@ -230,9 +213,8 @@ end
         index = Dict("start" => "2000-01-01T00:00:00", "resolution" => "1M", "repeat" => true, "ignore_year" => true)
         value = Dict("type" => "time_series", "data" => PyVector(data), "index" => index)
         object_parameter_values = [["country", "France", "apero_time", value]]
-        db_api.import_data(db_map; object_parameter_values=object_parameter_values)
-        db_map.commit_session("No comment")
-        using_spinedb(db_map)
+        import_data(db_url; object_parameter_values=object_parameter_values)
+        using_spinedb(db_url)
         France = country(:France)
         @test apero_time(country=France) isa TimeSeries
         @test apero_time(country=France, t=TimeSlice(DateTime(0, 1), DateTime(0, 2))) == data[1]
@@ -283,14 +265,13 @@ end
             ),
         )
         object_parameter_values = [["country", "France", "apero_time", value]]
-        db_api.import_data(
-            db_map;
+        import_data(
+            db_url;
             object_classes=object_classes,
             objects=objects,
             object_parameter_values=object_parameter_values,
         )
-        db_map.commit_session("No comment")
-        using_spinedb(db_map)
+        using_spinedb(db_url)
         France = country(:France)
         drunk = scenario(:drunk)
         sober = scenario(:sober)

--- a/test/util.jl
+++ b/test/util.jl
@@ -17,6 +17,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################################
 
+# Initialise an in-memory database to avoid `StackOverflowError` when running this file solo???
+using_spinedb("sqlite://")
+
 @testset "object_class_to_dict" begin
     objects = [Object(:silvester), Object(:tom)]
     parameter_values = Dict(obj => Dict(:age => parameter_value(k)) for (k, obj) in enumerate(objects))


### PR DESCRIPTION
Fixing most of the broken unit tests in `SpineInterface.jl`, caused by the change in the database interface. However, it seems that there's some issue related to parsing `Array` type values from their JSON representation.

Furthermore, I noticed that running `test/constructorts.jl` or `test/util.jl` without the preceding testsets results in a `StackOverflowError`, which I bypassed by initialising the in-memory db. Probably not the best solution, though, as something is clearly going wrong.

@manuelma I'd appreciate if you could take a look. I currently don't have a clue how the `Array` parameters should be parsed, so I don't know how to fix the remaining tests.