### PR TITLE
Timeseries access with datetime

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -112,6 +112,7 @@ end
 
 (p::TimePatternParameterValue)(; t::Union{DateTime,TimeSlice,Nothing}=nothing, kwargs...) = p(t)
 (p::TimePatternParameterValue)(::Nothing) = p.value
+(p::TimePatternParameterValue)(t::DateTime) = p(TimeSlice(t,t))
 function (p::TimePatternParameterValue)(t::TimeSlice)
     vals = [val for (tp, val) in p.value if overlaps(t, tp)]
     isempty(vals) && return nothing

--- a/src/util.jl
+++ b/src/util.jl
@@ -129,8 +129,8 @@ end
 (p::StandardTimeSeriesParameterValue)(; t::Union{DateTime,TimeSlice,Nothing}=nothing, kwargs...) = p(t)
 (p::StandardTimeSeriesParameterValue)(::Nothing) = p.value
 function (p::StandardTimeSeriesParameterValue)(t::DateTime)
+    p.value.ignore_year && (t -= Year(t))
     p.value.indexes[1] <= t <= p.value.indexes[end] || return nothing
-    p.value.ignore_year && (t -= Year(start(t)))
     p.value.values[max(1, searchsortedlast(p.value.indexes, t))]
 end
 function (p::StandardTimeSeriesParameterValue)(t::TimeSlice)

--- a/src/util.jl
+++ b/src/util.jl
@@ -120,7 +120,7 @@ function (p::TimePatternParameterValue)(t::TimeSlice)
 end
 
 function _search_overlap(ts::TimeSeries, t_start::DateTime, t_end::DateTime)
-    (t_start <= ts.indexes[end] && t_end > ts.indexes[1]) || return ()
+    (t_start <= ts.indexes[end] && t_end >= ts.indexes[1]) || return ()
     a = max(1, searchsortedlast(ts.indexes, t_start))
     b = searchsortedfirst(ts.indexes, t_end) - 1
     (a, b)
@@ -138,6 +138,7 @@ function (p::StandardTimeSeriesParameterValue)(t::TimeSlice)
     ab = _search_overlap(p.value, start(t), end_(t))
     isempty(ab) && return nothing
     a, b = ab
+    isempty(a:b) && return nothing
     vals = Iterators.filter(!isnan, p.value.values[a:b])
     mean(vals)
 end

--- a/test/api.jl
+++ b/test/api.jl
@@ -199,6 +199,30 @@ end
         @test isnothing(apero_time(country=country(:France), t=DateTime(100)))
         @test apero_time(country=country(:France), t=TimeSlice(DateTime(0), DateTime(100))) == 5
     end
+    @testset "repeating time_series" begin
+        isfile(path) && rm(path)
+        # NOTE! Repeating time series should always end with the same value as it started!
+        val = TimeSeries([DateTime(1), DateTime(2), DateTime(3), DateTime(4)], [4, 5, 6, 4], false, true)
+        parameters = Dict(:apero_time => Dict((country=:France,) => val))
+        write_parameters(parameters, url)
+        using_spinedb(url)
+        # NOTE! Leap-years cause cumulating one-day mismatches over time series repeated over multiple years...
+        @test apero_time(country=country(:France), t=DateTime(0)) == 5
+        @test apero_time(country=country(:France), t=DateTime(0,1,2)) == 6
+        @test apero_time(country=country(:France), t=TimeSlice(DateTime(0), DateTime(1))) == 5.5
+        @test apero_time(country=country(:France), t=TimeSlice(DateTime(1), DateTime(2))) == 4
+        @test apero_time(country=country(:France), t=TimeSlice(DateTime(1,2), DateTime(1,12))) == 4
+        @test apero_time(country=country(:France), t=DateTime(1)) == 4
+        @test apero_time(country=country(:France), t=DateTime(1,12)) == 4
+        @test apero_time(country=country(:France), t=TimeSlice(DateTime(2), DateTime(3))) == 5
+        @test apero_time(country=country(:France), t=DateTime(2)) == 5
+        @test apero_time(country=country(:France), t=TimeSlice(DateTime(1), DateTime(3))) == 4.5
+        @test apero_time(country=country(:France), t=DateTime(3)) == 6
+        @test apero_time(country=country(:France), t=TimeSlice(DateTime(3), DateTime(100))) == 6
+        @test isnothing(apero_time(country=country(:France), t=TimeSlice(DateTime(4), DateTime(100))))
+        @test isnothing(apero_time(country=country(:France), t=DateTime(100)))
+        @test apero_time(country=country(:France), t=TimeSlice(DateTime(0), DateTime(100))) == 5
+    end
     @testset "with report" begin
         isfile(path) && rm(path)
         parameters = Dict(:apero_time => Dict((country=:France,) => "later..."))

--- a/test/api.jl
+++ b/test/api.jl
@@ -202,13 +202,13 @@ end
     @testset "repeating time_series" begin
         isfile(path) && rm(path)
         # NOTE! Repeating time series should always end with the same value as it started!
-        val = TimeSeries([DateTime(1), DateTime(2), DateTime(3), DateTime(4)], [4, 5, 6, 4], false, true)
+        # NOTE! Needs to include a 4-year span to avoid 1-day mismatches caused by leap years.
+        val = TimeSeries([DateTime(1), DateTime(2), DateTime(3), DateTime(4), DateTime(5)], [4, 5, 6, 7, 4], false, true)
         parameters = Dict(:apero_time => Dict((country=:France,) => val))
         write_parameters(parameters, url)
         using_spinedb(url)
-        # NOTE! Leap-years cause cumulating one-day mismatches over time series repeated over multiple years...
-        @test apero_time(country=country(:France), t=DateTime(0)) == 5
-        @test apero_time(country=country(:France), t=DateTime(0,1,2)) == 6
+        @test apero_time(country=country(:France), t=DateTime(0)) == 7
+        # NOTE! The repeat-boundary behaves quite counterintuitively, but I don't know how to fix it...
         @test apero_time(country=country(:France), t=TimeSlice(DateTime(0), DateTime(1))) == 5.5
         @test apero_time(country=country(:France), t=TimeSlice(DateTime(1), DateTime(2))) == 4
         @test apero_time(country=country(:France), t=TimeSlice(DateTime(1,2), DateTime(1,12))) == 4
@@ -217,11 +217,14 @@ end
         @test apero_time(country=country(:France), t=TimeSlice(DateTime(2), DateTime(3))) == 5
         @test apero_time(country=country(:France), t=DateTime(2)) == 5
         @test apero_time(country=country(:France), t=TimeSlice(DateTime(1), DateTime(3))) == 4.5
-        @test apero_time(country=country(:France), t=DateTime(3)) == 6
-        @test apero_time(country=country(:France), t=TimeSlice(DateTime(3), DateTime(100))) == 6
-        @test isnothing(apero_time(country=country(:France), t=TimeSlice(DateTime(4), DateTime(100))))
-        @test isnothing(apero_time(country=country(:France), t=DateTime(100)))
-        @test apero_time(country=country(:France), t=TimeSlice(DateTime(0), DateTime(100))) == 5
+        @test apero_time(country=country(:France), t=DateTime(4)) == 7
+        # NOTE! The repeat-boundary behaves quite counterintuitively, but I don't know how to fix it...
+        @test apero_time(country=country(:France), t=TimeSlice(DateTime(4), DateTime(5))) == 5.5
+        @test apero_time(country=country(:France), t=DateTime(5)) == 4
+        @test apero_time(country=country(:France), t=TimeSlice(DateTime(5), DateTime(6))) == 4
+        @test apero_time(country=country(:France), t=TimeSlice(DateTime(5), DateTime(7))) == 4.5
+        @test apero_time(country=country(:France), t=DateTime(100)) == 7
+        @test apero_time(country=country(:France), t=TimeSlice(DateTime(0), DateTime(100))) == 5.2
     end
     @testset "with report" begin
         isfile(path) && rm(path)

--- a/test/api.jl
+++ b/test/api.jl
@@ -185,7 +185,7 @@ end
         write_parameters(parameters, url)
         using_spinedb(url)
         @test isnothing(apero_time(country=country(:France), t=DateTime(0)))
-        @test apero_time(country=country(:France), t=TimeSlice(DateTime(0), DateTime(1))) == 4
+        @test isnothing(apero_time(country=country(:France), t=TimeSlice(DateTime(0), DateTime(1))))
         @test apero_time(country=country(:France), t=TimeSlice(DateTime(1), DateTime(2))) == 4
         @test apero_time(country=country(:France), t=TimeSlice(DateTime(1,2), DateTime(1,12))) == 4
         @test apero_time(country=country(:France), t=DateTime(1)) == 4


### PR DESCRIPTION
Implementing a better way of accessing `TimeSeries` data with `DateTime` values, as well as fixing some issues with repeating time series and implementing new unit tests for repeating time series behaviour.

Unfortunately, the repeating time series behave a bit counter-intuitively over the repeat-boundary, and I couldn't find a way to get them to behave.