### PR TITLE
Fix array parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ test/test_out.sqlite
 examples/tutorial_spine_database/quick_start.sqlite
 examples/tutorial_spineopt_database/example_spineopt_database.sqlite
 .vscode/settings.json
+.zed/**
 test/deleteme.sqlite

--- a/src/api/parameter_value.jl
+++ b/src/api/parameter_value.jl
@@ -163,7 +163,9 @@ function _parse_db_value(index::Dict, data::Union{OrderedDict,Dict}, ::Val{:time
     vals = _parse_float.(values(data))
     TimeSeries(inds, vals, ignore_year, get(index, "repeat", false))
 end
-_parse_db_value(value::Dict, type::Val{:array}) = _parse_inner_value.(value["data"], Val(Symbol(value["value_type"])))
+function _parse_db_value(value::Dict, type::Val{:array})
+    _parse_inner_value.(value["data"], Val(Symbol(get(value, "value_type", "float"))))
+end
 function _parse_db_value(::Nothing, data::Array{T,1}, ::Val{:array}) where {T}
     _parse_inner_value.(data, Val(Symbol(_inner_type_str(T))))
 end

--- a/test/api.jl
+++ b/test/api.jl
@@ -67,9 +67,8 @@ function _test_indices_as_tuples()
         object_parameters = [["institution", "since_year"]]
         institutions = ["KTH", "ER"]
         objects = [["institution", x] for x in institutions]
-        object_parameter_values = [
-            ["institution", "KTH", "since_year", 1827], ["institution", "ER", "since_year", 2010]
-        ]
+        object_parameter_values =
+            [["institution", "KTH", "since_year", 1827], ["institution", "ER", "since_year", 2010]]
         import_test_data(
             db_url;
             object_classes=object_classes,
@@ -79,18 +78,16 @@ function _test_indices_as_tuples()
         )
         Y = Bind()
         using_spinedb(db_url, Y)
-        @test Set(indices_as_tuples(Y.since_year)) == Set([
-            (institution=Y.institution(:KTH),), (institution=Y.institution(:ER),)
-        ])
+        @test Set(indices_as_tuples(Y.since_year)) ==
+              Set([(institution=Y.institution(:KTH),), (institution=Y.institution(:ER),)])
     end
 end
 
 function _test_object_class_relationship_class_parameter()
     @testset "object_class, relationship_class, parameter" begin
         object_classes = ["institution", "country"]
-        relationship_classes = [
-            ["institution__country", ["institution", "country"]], ["country__institution", ["country", "institution"]]
-        ]
+        relationship_classes =
+            [["institution__country", ["institution", "country"]], ["country__institution", ["country", "institution"]]]
         object_parameters = [["institution", "since_year"]]
         relationship_parameters = [["institution__country", "people_count"], ["country__institution", "animal_count"]]
         import_test_data(
@@ -154,11 +151,7 @@ function _test_timeslice_relationships()
     ts01 = TimeSlice(DateTime(0), DateTime(1))
     ts12 = TimeSlice(DateTime(1), DateTime(2))
     ts23 = TimeSlice(DateTime(2), DateTime(3))
-    t_before_t = RelationshipClass(
-        :t_before_t,
-        [:t_before, :t_after],
-        [(ts01, ts12), (ts12, ts23)]
-    )
+    t_before_t = RelationshipClass(:t_before_t, [:t_before, :t_after], [(ts01, ts12), (ts12, ts23)])
     @test isempty(t_before_t(t_after=ts01))
     @test t_before_t(t_before=ts01) == [ts12]
     @test t_before_t(t_after=ts12) == [ts01]
@@ -188,10 +181,8 @@ end
 function _test_add_relationships()
     @testset "add_relationships" begin
         object_classes = ["institution", "country"]
-        relationship_classes = [
-            ["institution__country", ["institution", "country"]],
-            ["country__country", ["country", "country"]],
-        ]
+        relationship_classes =
+            [["institution__country", ["institution", "country"]], ["country__country", ["country", "country"]]]
         institutions = ["VTT", "KTH", "KUL", "ER", "UCD"]
         countries = ["Sweden", "France", "Finland", "Ireland", "Belgium"]
         objects = vcat([["institution", x] for x in institutions], [["country", x] for x in countries])
@@ -222,17 +213,14 @@ function _test_add_relationships()
             [(:ER, :France), (:ER, :Ireland)]
         ])
         @test isempty(Y.country__country())
-        add_relationships!(
-            Y.country__country,
-            [(country1=Y.country(:Sweden), country2=Y.country(:Sweden))]
-        )
+        add_relationships!(Y.country__country, [(country1=Y.country(:Sweden), country2=Y.country(:Sweden))])
         @test Y.country__country() == [(country1=Y.country(:Sweden), country2=Y.country(:Sweden))]
         add_relationships!(
             Y.country__country,
             [
                 (country1=Y.country(:Sweden), country2=Y.country(:Sweden)),
                 (country1=Y.country(:Finland), country2=Y.country(:Ireland)),
-            ]
+            ],
         )
         @test Y.country__country() == [
             (country1=Y.country(:Sweden), country2=Y.country(:Sweden)),
@@ -250,13 +238,13 @@ function _test_parse_db_value()
         string_value = "asd"
         array_data = [4, 8, 7]
         array_value = Dict("type" => "array", "value_type" => "float", "data" => array_data)
+        array_value_with_default_type = Dict("type" => "array", "data" => array_data)
         time_pattern_data = Dict("M1-4,M9-10" => 300, "M5-8" => 221.5)
         time_pattern_value = Dict("type" => "time_pattern", "data" => time_pattern_data)
         time_series_data = [1.0, 4.0, 5.0, -2.0, 7.0]
         time_series_index =
             Dict("start" => "2000-01-01T00:00:00", "resolution" => "1M", "repeat" => false, "ignore_year" => true)
-        time_series_value =
-            Dict("type" => "time_series", "data" => time_series_data, "index" => time_series_index)
+        time_series_value = Dict("type" => "time_series", "data" => time_series_data, "index" => time_series_index)
         map_value = Dict(
             "type" => "map",
             "index_type" => "str",
@@ -284,6 +272,8 @@ function _test_parse_db_value()
         @test parse_db_value(parse_db_value(bool_value)) == parse_db_value(bool_value)::Bool
         @test parse_db_value(parse_db_value(string_value)) == parse_db_value(string_value)::String
         @test parse_db_value(parse_db_value(array_value)) == parse_db_value(array_value)::Array
+        @test parse_db_value(parse_db_value(array_value_with_default_type)) ==
+              parse_db_value(array_value_with_default_type)::Array
         @test parse_db_value(parse_db_value(time_pattern_value)) == parse_db_value(time_pattern_value)::TimePattern
         @test parse_db_value(parse_db_value(time_series_value)) == parse_db_value(time_series_value)::TimeSeries
         @test parse_db_value(parse_db_value(map_value)) == parse_db_value(map_value)::Map
@@ -296,15 +286,14 @@ function _test_add_object_parameter_values()
         institutions = ["ER", "KTH"]
         objects = [["institution", x] for x in institutions]
         object_parameters = [["institution", "since_year"]]
-        object_parameter_values = [
-            ["institution", "KTH", "since_year", 1827], ["institution", "ER", "since_year", 2010]
-        ]
+        object_parameter_values =
+            [["institution", "KTH", "since_year", 1827], ["institution", "ER", "since_year", 2010]]
         import_test_data(
             db_url;
             object_classes=object_classes,
             objects=objects,
             object_parameters=object_parameters,
-            object_parameter_values=object_parameter_values
+            object_parameter_values=object_parameter_values,
         )
         Y = Bind()
         using_spinedb(db_url, Y)
@@ -314,9 +303,8 @@ function _test_add_object_parameter_values()
         @test Y.since_year(institution=ER) == 2010
         pvals = Dict(
             Object(:ER, :institution) => Dict(:since_year => parameter_value(2011)),
-            Object(:CORRE_LABS, :institution) => Dict(
-                :since_year => parameter_value(2022), :people_count => parameter_value(3)
-            ),
+            Object(:CORRE_LABS, :institution) =>
+                Dict(:since_year => parameter_value(2022), :people_count => parameter_value(3)),
         )
         add_object_parameter_values!(Y.institution, pvals)
         CORRE_LABS = Object(:CORRE_LABS, :institution)
@@ -330,26 +318,18 @@ end
 function _test_add_relationship_parameter_values()
     @testset "add_relationship_parameter_values" begin
         object_classes = ["institution", "country"]
-        relationship_classes = [
-            ["institution__country", ["institution", "country"]],
-            ["country__country", ["country", "country"]],
-        ]
-        relationship_parameters = [
-            ["institution__country", "people_count"],
-            ["country__country", "is_different"]
-        ]
+        relationship_classes =
+            [["institution__country", ["institution", "country"]], ["country__country", ["country", "country"]]]
+        relationship_parameters = [["institution__country", "people_count"], ["country__country", "is_different"]]
         institutions = ["VTT", "KTH", "KUL", "ER", "UCD"]
         countries = ["Sweden", "France", "Finland", "Ireland", "Belgium"]
         objects = vcat([["institution", x] for x in institutions], [["country", x] for x in countries])
-        institution_country_tuples =[
-            ["VTT", "Finland"], ["KTH", "Sweden"], ["KTH", "France"], ["KUL", "Belgium"], ["UCD", "Ireland"]
-        ]
-        relationships = [
-            ["institution__country", [inst, country]] for (inst, country) in institution_country_tuples
-        ]
+        institution_country_tuples =
+            [["VTT", "Finland"], ["KTH", "Sweden"], ["KTH", "France"], ["KUL", "Belgium"], ["UCD", "Ireland"]]
+        relationships = [["institution__country", [inst, country]] for (inst, country) in institution_country_tuples]
         relationship_parameter_values = [
-            ["institution__country", [inst, country], "people_count", k]
-            for (k, (inst, country)) in enumerate(institution_country_tuples)
+            ["institution__country", [inst, country], "people_count", k] for
+            (k, (inst, country)) in enumerate(institution_country_tuples)
         ]
         import_test_data(
             db_url;
@@ -372,21 +352,25 @@ function _test_add_relationship_parameter_values()
             ERFrance => Dict(:people_count => parameter_value(1)),
             ERIreland => Dict(:people_count => parameter_value(1)),
             ERSweden => Dict(:people_count => parameter_value(1)),
-            KTHFrance => Dict(:people_count => parameter_value(0))
+            KTHFrance => Dict(:people_count => parameter_value(0)),
         )
         add_relationship_parameter_values!(Y.institution__country, pvals)
         @test length(Y.institution__country()) === 8
-        @test Set((x.name, y.name) for (x, y) in Y.institution__country()) == Set([
-            [(Symbol(x), Symbol(y)) for (x, y) in institution_country_tuples]
-            [(:ER, :France), (:ER, :Ireland), (:ER, :Sweden)]
-        ])
+        @test Set((x.name, y.name) for (x, y) in Y.institution__country()) == Set(
+            [
+                [(Symbol(x), Symbol(y)) for (x, y) in institution_country_tuples]
+                [(:ER, :France), (:ER, :Ireland), (:ER, :Sweden)]
+            ],
+        )
         @test Y.people_count(; ERFrance...) == 1
         @test Y.people_count(; ERIreland...) == 1
         @test Y.people_count(; ERSweden...) == 1
         @test Y.people_count(; KTHFrance...) == 0
         pvals = Dict(
-            (country1=Y.country(:Sweden), country2=Y.country(:Sweden)) => Dict(:is_different => parameter_value(false)),
-            (country1=Y.country(:Sweden), country2=Y.country(:France)) => Dict(:is_different => parameter_value(true)),
+            (country1=Y.country(:Sweden), country2=Y.country(:Sweden)) =>
+                Dict(:is_different => parameter_value(false)),
+            (country1=Y.country(:Sweden), country2=Y.country(:France)) =>
+                Dict(:is_different => parameter_value(true)),
         )
         add_relationship_parameter_values!(Y.country__country, pvals)
         @test Y.is_different(country1=Y.country(:Sweden), country2=Y.country(:Sweden)) == false
@@ -409,12 +393,8 @@ function _test_write_parameters()
         end
         @testset "date_time & duration" begin
             isfile(path) && rm(path)
-            parameters = Dict(
-                :apero_time => Dict(
-                    (country=:France,) => DateTime(1),
-                    (country=:Sweden, drink=:vodka) => Hour(1),
-                ),
-            )
+            parameters =
+                Dict(:apero_time => Dict((country=:France,) => DateTime(1), (country=:Sweden, drink=:vodka) => Hour(1)))
             write_parameters(parameters, url)
             Y = Bind()
             using_spinedb(url, Y)
@@ -431,9 +411,8 @@ function _test_write_parameters()
         end
         @testset "time_pattern" begin
             isfile(path) && rm(path)
-            val = Dict(
-                SpineInterface.parse_time_period("D2-5") => 30.5, SpineInterface.parse_time_period("D6-7") => 24.7
-            )
+            val =
+                Dict(SpineInterface.parse_time_period("D2-5") => 30.5, SpineInterface.parse_time_period("D6-7") => 24.7)
             @test val isa SpineInterface.TimePattern
             parameters = Dict(:apero_time => Dict((country=:France,) => val))
             write_parameters(parameters, url)
@@ -444,8 +423,10 @@ function _test_write_parameters()
             @test Y.apero_time(country=Y.country(:France), t=TimeSlice(DateTime(0, 1, 1), DateTime(0, 1, 5))) == 30.5
             @test Y.apero_time(country=Y.country(:France), t=DateTime(0, 1, 2)) == 30.5
             @test Y.apero_time(country=Y.country(:France), t=DateTime(0, 1, 5)) == 30.5
-            @test Y.apero_time(country=Y.country(:France), t=TimeSlice(DateTime(0, 1, 5), DateTime(0, 1, 6, 1))) == (30.5 + 24.7) / 2.
-            @test Y.apero_time(country=Y.country(:France), t=TimeSlice(DateTime(0, 1, 6), DateTime(0, 1, 6, 10))) == 24.7
+            @test Y.apero_time(country=Y.country(:France), t=TimeSlice(DateTime(0, 1, 5), DateTime(0, 1, 6, 1))) ==
+                  (30.5 + 24.7) / 2.0
+            @test Y.apero_time(country=Y.country(:France), t=TimeSlice(DateTime(0, 1, 6), DateTime(0, 1, 6, 10))) ==
+                  24.7
             @test Y.apero_time(country=Y.country(:France), t=DateTime(0, 1, 6)) == 24.7
             @test Y.apero_time(country=Y.country(:France), t=TimeSlice(DateTime(0, 1, 7), DateTime(0, 1, 8))) == 24.7
             @test Y.apero_time(country=Y.country(:France), t=DateTime(0, 1, 7)) == 24.7
@@ -479,7 +460,10 @@ function _test_write_parameters()
             # NOTE: Repeating time series should always end with the same value as it started!
             # NOTE: Needs to include a 4-year span to avoid 1-day mismatches caused by leap years.
             val = TimeSeries(
-                [DateTime(1), DateTime(2), DateTime(3), DateTime(4), DateTime(5)], [4, 5, 6, 7, 4], false, true
+                [DateTime(1), DateTime(2), DateTime(3), DateTime(4), DateTime(5)],
+                [4, 5, 6, 7, 4],
+                false,
+                true,
             )
             parameters = Dict(:apero_time => Dict((country=:France,) => val))
             write_parameters(parameters, url)
@@ -556,8 +540,7 @@ function _test_maximum_parameter_value()
         time_series_data = [1.0, 4.0, 5.0, NaN, 7.0]
         time_series_index =
             Dict("start" => "2000-01-01T00:00:00", "resolution" => "1M", "repeat" => false, "ignore_year" => true)
-        time_series_value =
-            Dict("type" => "time_series", "data" => time_series_data, "index" => time_series_index)
+        time_series_value = Dict("type" => "time_series", "data" => time_series_data, "index" => time_series_index)
         map_value = Dict(
             "type" => "map",
             "index_type" => "str",
@@ -625,15 +608,14 @@ function _test_import_data()
             :array_parameter => parameter_value(ar),
             :timepattern_parameter => parameter_value(tp),
             :timeseries_parameter => parameter_value(ts),
-            :map_parameter => parameter_value(map)
+            :map_parameter => parameter_value(map),
         )
         # Create objects and object class for testing
         to1 = Object(:test_object_1)
         to2 = Object(:test_object_2)
         original_oc = ObjectClass(:test_oc, [to1, to2], Dict(to1 => pv_dict), pv_dict)
-        original_rc = RelationshipClass(
-            :test_rc, [:test_oc, :test_oc], [(to1, to2)], Dict((to1, to2) => pv_dict), pv_dict
-        )
+        original_rc =
+            RelationshipClass(:test_rc, [:test_oc, :test_oc], [(to1, to2)], Dict((to1, to2) => pv_dict), pv_dict)
         # Import the newly created `ObjectClass` and `RelationshipClass`
         @test import_data(db_url, original_oc, "Import test object class.") == [21, []]
         @test import_data(db_url, original_rc, "Import test relationship class.") == [20, []]
@@ -668,15 +650,11 @@ function _test_difference()
         right = export_data(db_url)
         left_diff = difference(left, right)
         left_parts = [split(strip(x), "  ") for x in split(left_diff, '\n') if !isempty(x)]
-        left_expected = [
-            ["entity classes", "country"], ["institution__country"], ["parameters", "people_count"]
-        ]
+        left_expected = [["entity classes", "country"], ["institution__country"], ["parameters", "people_count"]]
         @test left_parts == left_expected
         right_diff = difference(right, left)
         right_parts = [split(strip(x), "  ") for x in split(right_diff, '\n') if !isempty(x)]
-        right_expected = [
-            ["entity classes", "idea"], ["institution__idea"], ["parameters", "creator"]
-        ]
+        right_expected = [["entity classes", "idea"], ["institution__idea"], ["parameters", "creator"]]
         @test right_parts == right_expected
     end
 end
@@ -696,8 +674,7 @@ function _test_indexed_values()
         time_series_data = [1.0, 4.0, 5.0, -100.0, 7.0]
         time_series_index =
             Dict("start" => "2000-01-01T00:00:00", "resolution" => "1M", "repeat" => false, "ignore_year" => true)
-        time_series_value =
-            Dict("type" => "time_series", "data" => time_series_data, "index" => time_series_index)
+        time_series_value = Dict("type" => "time_series", "data" => time_series_data, "index" => time_series_index)
         map_value = Dict(
             "type" => "map",
             "index_type" => "str",
@@ -741,7 +718,7 @@ function _test_indexed_values()
         # @show collect(indexed_values(people_count(country=country(:Sweden))))
         @test indexed_values(Y.people_count(country=Y.country(:Finland))) == Dict(
             (:drunk, (DateTime("1999-12-01T00:00:00"), DateTime("0000-01-01T00:00:00"))) => 4.0,
-            (:drunk, (DateTime("1999-12-01T00:00:00"), DateTime("0000-02-01T00:00:00"))) => 5.6
+            (:drunk, (DateTime("1999-12-01T00:00:00"), DateTime("0000-02-01T00:00:00"))) => 5.6,
         )
         @test indexed_values(Y.people_count(country=Y.country(:Ireland))) == Dict(1 => 4.0, 2 => 8.0, 3 => 7.0)
         @test (indexed_values(Y.people_count(country=Y.country(:Netherlands)))) == Dict(
@@ -749,7 +726,7 @@ function _test_indexed_values()
             DateTime("0000-02-01T00:00:00") => 4.0,
             DateTime("0000-03-01T00:00:00") => 5.0,
             DateTime("0000-04-01T00:00:00") => -100.0,
-            DateTime("0000-05-01T00:00:00") => 7.0
+            DateTime("0000-05-01T00:00:00") => 7.0,
         )
         @test indexed_values(Y.people_count(country=Y.country(:Denmark))) == Dict(nothing => nothing)
     end
@@ -818,11 +795,7 @@ function _test_write_interface()
         end
         @testset "entity_classes / object_parameters / relationship_parameters format" begin
             template = Dict(
-                "entity_classes" => [
-                    ["commodity", []],
-                    ["node", []],
-                    ["node__commodity", ["node", "commodity"]],
-                ],
+                "entity_classes" => [["commodity", []], ["node", []], ["node__commodity", ["node", "commodity"]]],
                 "object_parameters" => [["node", "demand"]],
                 "relationship_parameters" => [["node__commodity", "flow"]],
             )
@@ -855,9 +828,7 @@ function _test_write_interface()
         @testset "names are sorted alphabetically" begin
             template = Dict(
                 "object_classes" => [["zoo"], ["apple"], ["mango"]],
-                "relationship_classes" => [
-                    ["zoo__apple", ["zoo", "apple"]], ["apple__mango", ["apple", "mango"]]
-                ],
+                "relationship_classes" => [["zoo__apple", ["zoo", "apple"]], ["apple__mango", ["apple", "mango"]]],
                 "parameter_definitions" => [["zoo", "zzz_param"], ["apple", "aaa_param"]],
             )
             io = IOBuffer()
@@ -879,10 +850,8 @@ function _test_write_interface()
             template = Dict(
                 "object_classes" => [["institution"], ["country"]],
                 "relationship_classes" => [["institution__country", ["institution", "country"]]],
-                "parameter_definitions" => [
-                    ["institution", "people_count"],
-                    ["institution__country", "people_count"],
-                ],
+                "parameter_definitions" =>
+                    [["institution", "people_count"], ["institution__country", "people_count"]],
             )
             io = IOBuffer()
             write_interface(io, template)
@@ -891,11 +860,7 @@ function _test_write_interface()
             @test count("export people_count", output) == 1
         end
         @testset "object class only, no relationships or parameters" begin
-            template = Dict(
-                "object_classes" => [["node"]],
-                "relationship_classes" => [],
-                "parameter_definitions" => [],
-            )
+            template = Dict("object_classes" => [["node"]], "relationship_classes" => [], "parameter_definitions" => [])
             io = IOBuffer()
             write_interface(io, template)
             output = String(take!(io))


### PR DESCRIPTION
This PR fixes a bug where SpineInterface failed to parse arrays that did not have a `value_type` field.

As the [specification](https://spine-database-api.readthedocs.io/en/latest/parameter_value_format.html#array) says, `value_type` defaults to `float` if omitted.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted nicely
- [x] Unit tests pass
