### PR TITLE
Use latest 3rd party actions in GitHub actions

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -32,10 +32,10 @@ jobs:
     name: Julia ${{ inputs.julia-version }} - ${{ inputs.host-os }}
     runs-on: ${{ inputs.host-os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ${{ inputs.repository }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}
       - uses: julia-actions/setup-julia@v2
@@ -50,9 +50,9 @@ jobs:
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
         if: inputs.coverage && inputs.julia-version == '1' && inputs.host-os == 'ubuntu-latest'
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         if: inputs.coverage && inputs.julia-version == '1' && inputs.host-os == 'ubuntu-latest'
         with:
-          file: lcov.info
+          files: lcov.info
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install dependencies


### PR DESCRIPTION
GitHub will require actions that support Node.js 24 in the future.

`setup-julia` needs to be updated still when they release version 3.

No functional changes. No associated issue.

## Checklist before merging
~~- [ ] Documentation is up-to-date~~
~~- [ ] Unit tests have been added/updated accordingly~~
~~- [ ] Code has been formatted nicely~~
- [x] Unit tests pass
